### PR TITLE
Move credentials to K8s secret and add APP_SECRET, MAILER_FROM, MAILER_URL as config options

### DIFF
--- a/charts/kimai2/Chart.yaml
+++ b/charts/kimai2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kimai2
 description: A Helm chart for Kubernetes
 type: application
-version: 1.1.5
+version: 1.2.0
 appVersion: "apache"
 
 dependencies:

--- a/charts/kimai2/README.md
+++ b/charts/kimai2/README.md
@@ -66,11 +66,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Kimai Configuration parameters
 
-| Name                                   | Description                           | Value                |
-| -------------------------------------- | ------------------------------------- | -------------------- |
-| `kimaiAdminEmail`                      | Email for the superadmin account      | `admin@kimai.local`  |
-| `kimaiAdminPassword`                   | Password for the superadmin account   | `changemeplease`     |
-| `kimaiEnvironment`                     | Kimai environment name                | `prod`               |
+| Name                                   | Description                                        | Value                              |
+| -------------------------------------- | -------------------------------------------------- | ---------------------------------- |
+| `kimaiAppSecret`                       | Secret used to encrypt session cookies             | `change_this_to_something_unique`  |
+| `kimaiAdminEmail`                      | Email for the superadmin account                   | `admin@kimai.local`                |
+| `kimaiAdminPassword`                   | Password for the superadmin account                | `changemeplease`                   |
+| `kimaiEnvironment`                     | Kimai environment name                             | `prod`                             |
+| `kimaiMailerUrl`                       | SMTP connection for emails                         | `null://localhost`                 |
+| `kimaiMailerFrom`                      | Application specific “from” address for all emails | `kimai@example.com`                |
 
 ### Kimai deployment parameters
 

--- a/charts/kimai2/templates/deployment.yaml
+++ b/charts/kimai2/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: {{ .Values.kimaiEnvironment }}
             - name: TRUSTED_HOSTS
               value: localhost,{{ .Values.ingress.hostname }}
+            - name: MAILER_FROM
+              value: {{ .Values.kimaiMailerFrom }}
           envFrom:
             - secretRef:
                 name: {{ include "kimai2.name" . }}-secret

--- a/charts/kimai2/templates/deployment.yaml
+++ b/charts/kimai2/templates/deployment.yaml
@@ -38,14 +38,13 @@ spec:
           env:
             - name: ADMINMAIL
               value: {{ .Values.kimaiAdminEmail }}
-            - name: ADMINPASS
-              value: {{ .Values.kimaiAdminPassword }}
             - name: APP_ENV
               value: {{ .Values.kimaiEnvironment }}
-            - name: DATABASE_URL
-              value: {{ include "kimai2.databaseUrl" . }}
             - name: TRUSTED_HOSTS
               value: localhost,{{ .Values.ingress.hostname }}
+          envFrom:
+            - secretRef:
+                name: {{ include "kimai2.name" . }}-secret
           ports:
             - name: http
               containerPort: 8001

--- a/charts/kimai2/templates/secret.yaml
+++ b/charts/kimai2/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kimai2.name" . }}-secret
+  labels:
+    {{- include "kimai2.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  APP_SECRET: {{ .Values.appSecret }}
+  ADMINPASS: {{ .Values.kimaiAdminPassword }}
+  DATABASE_URL: {{ include "kimai2.databaseUrl" . }}

--- a/charts/kimai2/templates/secret.yaml
+++ b/charts/kimai2/templates/secret.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "kimai2.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  APP_SECRET: {{ .Values.appSecret }}
+  APP_SECRET: {{ .Values.kimaiAppSecret }}
   ADMINPASS: {{ .Values.kimaiAdminPassword }}
   DATABASE_URL: {{ include "kimai2.databaseUrl" . }}
+  MAILER_URL: {{ .Values.kimaiMailerUrl }}

--- a/charts/kimai2/templates/secret.yaml
+++ b/charts/kimai2/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "kimai2.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  APP_SECRET: {{ .Values.kimaiAppSecret }}
   ADMINPASS: {{ .Values.kimaiAdminPassword }}
+  APP_SECRET: {{ .Values.kimaiAppSecret }}
   DATABASE_URL: {{ include "kimai2.databaseUrl" . }}
   MAILER_URL: {{ .Values.kimaiMailerUrl }}

--- a/charts/kimai2/values.yaml
+++ b/charts/kimai2/values.yaml
@@ -30,6 +30,9 @@ nameOverride:
 ##
 fullnameOverride:
 
+## @param kimaiAppSecret Secret used to encrypt session cookies (users will be logged out if you change it)
+##
+kimaiAppSecret: change_this_to_something_unique
 ## @param kimaiAdminEmail Email for the superadmin account
 ##
 kimaiAdminEmail: admin@kimai.local
@@ -39,6 +42,12 @@ kimaiAdminPassword: changemeplease
 ## @param kimaiEnvironment Kimai environment name
 ##
 kimaiEnvironment: prod
+## @param kimaiMailerUrl Smtp connection for emails
+##
+kimaiMailerUrl: null://localhost
+## @param kimaiMailerFrom Application specific “from” address for all emails
+##
+kimaiMailerFrom: kimai@example.com
 
 podAnnotations: {}
 


### PR DESCRIPTION
This PR adds the following chart configuration options (stored in a new K8s secret):

- `kimaiAppSecret` to define the cookie encryption secret (which was set to the default value up to now)
- `kimaiMailerUrl` and `kimaiMailerFrom` to set up SMTP for Kimai

Existing credentials like `DATABASE_URL` and `ADMINPASS` have been moved to the secret instead of passing them directly in `env`.