### PR TITLE
Fix Nominatim download URLs

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -16,7 +16,8 @@ spec:
               name: data
           command:
             - curl
-            - https://www.nominatim.org/data/wikimedia-importance.sql.gz
+            - https://nominatim.org/data/wikimedia-importance.sql.gz
+            - -L
             - -o
             - wikimedia-importance.sql.gz
 {{- end }}
@@ -30,7 +31,8 @@ spec:
               name: data
           command:
             - curl
-            - https://www.nominatim.org/data/gb_postcode_data.sql.gz
+            - https://nominatim.org/data/gb_postcode_data.sql.gz
+            - -L
             - -o
             - gb_postcode_data.sql.gz
 {{- end }}
@@ -44,7 +46,8 @@ spec:
               name: data
           command:
             - curl
-            - https://www.nominatim.org/data/us_postcode_data.sql.gz
+            - https://nominatim.org/data/us_postcode_data.sql.gz
+            - -L
             - -o
             - us_postcode_data.sql.gz
 {{- end }}


### PR DESCRIPTION
- Update Nominatim SQL file download URLs for wikimedia importance data, US and GB postcodes.

Based on [this](https://github.com/mediagis/nominatim-docker/commit/3fb113ce2dd20dd0404a5daa5fc3bce05aeaf54c) and [this](https://github.com/mediagis/nominatim-docker/commit/78ad0ba380c68b242bc3ee66e102cf12ec2d1bd5) commits from the official their dockerfile repo 