### PR TITLE
Allow use of custom import style

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nominatim/README.md
+++ b/charts/nominatim/README.md
@@ -122,6 +122,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `nominatimInitialize.importGB_Postcode`    | If external GB postcodes should be imported                   | `false`               |
 | `nominatimInitialize.importUS_Postcode`    | If external US postcodes should be imported                   | `false`               |
 | `nominatimInitialize.importStyle`          | Nominatim import style                                        | `full`                |
+| `nominatimInitialize.customStyleUrl`       | Custom import style file URL                                  | `nil`                 |
 | `nominatimInitialize.threads`              | The number of thread used by the import                       | `16`                  |
 
 ### Nominatim Replication Configuration parameters
@@ -216,6 +217,11 @@ This chart provides support for Ingress resources. If an Ingress controller, suc
 
 To enable Ingress integration, set `ingress.enabled` to `true`. The `ingress.hostname` property can be used to set the host name. The `ingress.tls` parameter can be used to add the TLS configuration for this host.
 
+### Custom Import Style
+
+If none of the [default styles](https://nominatim.org/release-docs/latest/admin/Import/#filtering-imported-data) satisfies your needs, you can provide your [customized style file](https://nominatim.org/release-docs/latest/customize/Import-Styles/) by setting the `nominatimInitialize.customStyleUrl` value.
+
+Make sure the file is publicly available for init job to download it. [Example](https://raw.githubusercontent.com/osm-search/Nominatim/master/settings/import-street.style)
 ### TLS secrets
 
 The chart also facilitates the creation of TLS secrets for use with the Ingress controller, with different options for certificate management.

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -7,6 +7,21 @@ spec:
   template:
     spec:
       initContainers:
+{{- if .Values.nominatimInitialize.customStyleUrl }}
+        - name: download-custom-style
+          image: curlimages/curl
+          workingDir: /nominatim
+          volumeMounts:
+            - mountPath: /nominatim
+              name: data
+          command:
+            - curl
+            - {{ .Values.nominatimInitialize.customStyleUrl }}
+            - -L
+            - -o
+            - custom.style
+{{- end }}
+
 {{- if .Values.nominatimInitialize.importWikipedia }}
         - name: download-wikipedia
           image: curlimages/curl
@@ -86,8 +101,13 @@ spec:
           workingDir: /nominatim
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            {{- if .Values.nominatimInitialize.customStyleUrl }}
+            - name: NOMINATIM_IMPORT_STYLE
+              value: /nominatim/custom.style
+            {{- else }}
             - name: NOMINATIM_IMPORT_STYLE
               value: {{ .Values.nominatimInitialize.importStyle }}
+            {{- end }}
             - name: NOMINATIM_DATABASE_DSN
               value: {{ include "nominatim.databaseUrl" . }}
             - name: NOMINATIM_DATABASE_MODULE_PATH

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -35,6 +35,7 @@ nominatimInitialize:
   importGB_Postcode: false
   importUS_Postcode: false
   importStyle: full
+  # customStyleUrl: https://raw.githubusercontent.com/david-mart/Nominatim/master/settings/import-street.style
   threads: 16
 
 nominatimReplications:


### PR DESCRIPTION
Hi there, while using your helm chart for my deployments, I found that using default import styles wasn't good enough for my project, so I had to implement custom style file support. 

Decided to shoot this PR in case someone needs this in future.