### PR TITLE
Warm up database caches and add some verbose logging

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.0
+version: 3.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -132,6 +132,13 @@ spec:
                   nominatim freeze
                 fi
               fi;
+              
+              echo "Import job done. Warming up database indices."
+              
+              nominatim admin --warm
+              
+              echo "Warming finished."
+              echo "Initialization finished. Please continue with step 2 now."
 
           volumeMounts:
             - mountPath: /nominatim


### PR DESCRIPTION
It was a bit unclear to me when the initialization actually finished. Had to derive that by pgSQL cpu utilization and comparison with my local docker setup log output. 

Also, the official docker image is prewarming caches on PostgreSQL before requests are accepted. I found this quite useful and added it to the init job, too.