### PR TITLE
[nominatim][bugfix] User agent for initJob curl, handle non-success response

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.5.0
+version: 3.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -31,3 +31,6 @@ dependencies:
     version: 11.6.20
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
+
+annotations:
+  repository: robjuz/helm-charts

--- a/charts/nominatim/templates/_helpers.tpl
+++ b/charts/nominatim/templates/_helpers.tpl
@@ -128,3 +128,10 @@ pgsql:host={{ include "nominatim.databaseHost" . }};port={{ include "nominatim.d
 {{- define "nominatim.uiUrl" -}}
 {{- printf "https://github.com/osm-search/nominatim-ui/releases/download/v%s/nominatim-ui-%s.tar.gz" .Values.nominatimUi.version .Values.nominatimUi.version }}
 {{- end }}
+
+{{/*
+Create user agent string for curl
+*/}}
+{{- define "chart.userAgent" -}}
+{{- printf "%s/%s:%s" .Chart.Annotations.Repository .Chart.Name .Chart.Version }}
+{{- end }}

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -25,12 +25,14 @@ spec:
               name: data
           command:
             - curl
+            - -A {{ include "chart.userAgent" . }}
             - {{ .Values.nominatimInitialize.customStyleUrl }}
             - -L
+            - -f
             - -o
             - custom.style
 {{- end }}
-
+            - -A {{ include "chart.userAgent" . }}
 {{- if .Values.nominatimInitialize.importWikipedia }}
         - name: download-wikipedia
           image: curlimages/curl
@@ -40,8 +42,10 @@ spec:
               name: data
           command:
             - curl
+            - -A {{ include "chart.userAgent" . }}
             - {{ .Values.nominatimInitialize.wikipediaUrl }}
             - -L
+            - -f
             - -o
             - wikimedia-importance.sql.gz
 {{- end }}
@@ -55,8 +59,10 @@ spec:
               name: data
           command:
             - curl
+            - -A {{ include "chart.userAgent" . }}
             - https://www.nominatim.org/data/gb_postcodes.csv.gz
             - -L
+            - -f
             - -o
             - gb_postcodes.csv.gz
 {{- end }}
@@ -70,8 +76,10 @@ spec:
               name: data
           command:
             - curl
+            - -A {{ include "chart.userAgent" . }}
             - https://www.nominatim.org/data/us_postcodes.csv.gz
             - -L
+            - -f
             - -o
             - us_postcodes.csv.gz
 {{- end }}
@@ -84,9 +92,11 @@ spec:
               name: data
           command:
             - curl
-            - -L
+            - -A {{ include "chart.userAgent" . }}
             - {{ .Values.nominatimInitialize.pbfUrl }}
             - --create-dirs
+            - -L
+            - -f
             - -o
             - data.osm.pbf
 

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -32,7 +32,7 @@ spec:
             - -o
             - custom.style
 {{- end }}
-            - -A {{ include "chart.userAgent" . }}
+
 {{- if .Values.nominatimInitialize.importWikipedia }}
         - name: download-wikipedia
           image: curlimages/curl


### PR DESCRIPTION
Provide user agent on curl, mainly because of [this](https://github.com/osm-search/Nominatim/issues/2929#issuecomment-1368513962), also added `-f` (`--fail`) which changes the return code of curl command if http status is not success.
(I've added user agent to all init job curls, althought it is only required by https://nominatim.org/data)

Implements #45.