### PR TITLE
Add option to define custom hardware resources for init job

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.7.0
+version: 3.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nominatim/README.md
+++ b/charts/nominatim/README.md
@@ -119,17 +119,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Nominatim Initialisation Configuration parameters
 
-| Name                                       | Description                                                   | Value                |
-| ------------------------------------------ | ------------------------------------------------------------- | -------------------- |
-| `nominatimInitialize.enabled`              | enable/disable init job                                       | `false `             |
-| `nominatimInitialize.pbfUrl`               | URL of the pbf file to import                                 | `https://download.geofabrik.de/europe/germany/sachsen-latest.osm.pbf` |
-| `nominatimInitialize.importWikipedia`      | If additional Wikipedia/Wikidata rankings should be imported  | `false`               |
-| `nominatimInitialize.wikipediaUrl`         | Wikipedia/Wikidata rankings file URL                          | `https://nominatim.org/data/wikimedia-importance.sql.gz`              |
-| `nominatimInitialize.importGB_Postcode`    | If external GB postcodes should be imported                   | `false`               |
-| `nominatimInitialize.importUS_Postcode`    | If external US postcodes should be imported                   | `false`               |
-| `nominatimInitialize.importStyle`          | Nominatim import style                                        | `full`                |
-| `nominatimInitialize.customStyleUrl`       | Custom import style file URL                                  | `nil`                 |
-| `nominatimInitialize.threads`              | The number of thread used by the import                       | `16`                  |
+| Name                                    | Description                                                  | Value                                                                 |
+|-----------------------------------------|--------------------------------------------------------------|-----------------------------------------------------------------------|
+| `nominatimInitialize.enabled`           | enable/disable init job                                      | `false `                                                              |
+| `nominatimInitialize.pbfUrl`            | URL of the pbf file to import                                | `https://download.geofabrik.de/europe/germany/sachsen-latest.osm.pbf` |
+| `nominatimInitialize.importWikipedia`   | If additional Wikipedia/Wikidata rankings should be imported | `false`                                                               |
+| `nominatimInitialize.wikipediaUrl`      | Wikipedia/Wikidata rankings file URL                         | `https://nominatim.org/data/wikimedia-importance.sql.gz`              |
+| `nominatimInitialize.importGB_Postcode` | If external GB postcodes should be imported                  | `false`                                                               |
+| `nominatimInitialize.importUS_Postcode` | If external US postcodes should be imported                  | `false`                                                               |
+| `nominatimInitialize.importStyle`       | Nominatim import style                                       | `full`                                                                |
+| `nominatimInitialize.customStyleUrl`    | Custom import style file URL                                 | `nil`                                                                 |
+| `nominatimInitialize.threads`           | The number of thread used by the import                      | `16`                                                                  |
+| `nominatimInitialize.resources`         | Define resources requests and limits for the init container  | `{}`                                                                  |
 
 ### Nominatim Replication Configuration parameters
 

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -170,6 +170,10 @@ spec:
               name: flatnode
               subPath: flatnode
             {{- end }}
+          {{- if .Values.nominatimInitialize.resources }}
+          resources:
+            {{- toYaml .Values.nominatimInitialize.resources | nindent 12 }}
+          {{- end }}
       restartPolicy: OnFailure
       volumes:
         {{- if  .Values.flatnode.enabled }}

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -42,7 +42,7 @@ commonAnnotations: {}
 commonLabels: {}
 
 nominatimInitialize:
-  enabled: false
+  enabled: true
   pbfUrl: https://download.geofabrik.de/europe/germany/sachsen-latest.osm.pbf
   importWikipedia: false
   importGB_Postcode: false
@@ -52,6 +52,17 @@ nominatimInitialize:
   threads: 16
   freeze: false
   wikipediaUrl: https://nominatim.org/data/wikimedia-importance.sql.gz
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+#    requests:
+#      cpu: 4000m
+#      memory: 4Gi
+#    limits:
+#      cpu: 4000m
+#      memory: 4Gi
 
 nominatimReplications:
   enabled: false

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -42,7 +42,7 @@ commonAnnotations: {}
 commonLabels: {}
 
 nominatimInitialize:
-  enabled: true
+  enabled: false
   pbfUrl: https://download.geofabrik.de/europe/germany/sachsen-latest.osm.pbf
   importWikipedia: false
   importGB_Postcode: false


### PR DESCRIPTION
When importing Germany to Postgres, after approx. 10 minutes the container exits with SigKill. It's not entirely sure why that is, however I suppose its because Google Kubernetes Engine sets 0.5 CPU, 2 Gi memory as default resources. 

Some forum posts suggest that it indeed could have something to do with the too low HW setup.