### PR TITLE
Implement the feature to retrieve configuration data from an existing secret

### DIFF
--- a/charts/kimai2/Chart.yaml
+++ b/charts/kimai2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kimai2
 description: A Helm chart for Kubernetes
 type: application
-version: 3.0.5
+version: 3.0.6
 appVersion: "apache-2.0.23-prod"
 
 dependencies:

--- a/charts/kimai2/README.md
+++ b/charts/kimai2/README.md
@@ -85,17 +85,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Kimai Configuration parameters
 
-| Name                      | Description                                                                | Value                             |
-|---------------------------|----------------------------------------------------------------------------|-----------------------------------|
-| `kimaiEnvironment`        | Kimai environment name                                                     | `prod`                            |
-| `kimaiAppSecret`          | Secret used to encrypt session cookies                                     | `change_this_to_something_unique` |
-| `kimaiAdminEmail`         | Email for the superadmin account                                           | ``                                |
-| `kimaiAdminPassword`      | Password for the superadmin account                                        | ``                                |
-| `kimaiMailerFrom`         | Application specific “from” address for all emails                         | `kimai@example.com`               |
-| `kimaiMailerUrl`          | SMTP connection for emails                                                 | `null://localhost`                |
-| `kimaiTrustedProxies`     |                                                                            | `""`                              |
-| `existingSecret`          | Name of existing secret containing Kimai credentials                       | `""`                              |
-| `configurationFromSecret` | Use secret kimai2-config containing “local.yaml“ key as configuration file | `""`                              |
+| Name                      | Description                                                                                                       | Value                             |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------|-----------------------------------|
+| `kimaiEnvironment`        | Kimai environment name                                                                                            | `prod`                            |
+| `kimaiAppSecret`          | Secret used to encrypt session cookies                                                                            | `change_this_to_something_unique` |
+| `kimaiAdminEmail`         | Email for the superadmin account                                                                                  | ``                                |
+| `kimaiAdminPassword`      | Password for the superadmin account                                                                               | ``                                |
+| `kimaiMailerFrom`         | Application specific “from” address for all emails                                                                | `kimai@example.com`               |
+| `kimaiMailerUrl`          | SMTP connection for emails                                                                                        | `null://localhost`                |
+| `kimaiTrustedProxies`     |                                                                                                                   | `""`                              |
+| `existingSecret`          | Name of existing secret containing Kimai credentials                                                              | `""`                              |
+| `configurationFromSecret` | Use an existing secret match the common.names.fullname template containing “local.yaml“ key as configuration file | `false`                           |
 
 ### Kimai deployment parameters
 

--- a/charts/kimai2/README.md
+++ b/charts/kimai2/README.md
@@ -85,16 +85,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Kimai Configuration parameters
 
-| Name                  | Description                                          | Value                             |
-|-----------------------|------------------------------------------------------|-----------------------------------|
-| `kimaiEnvironment`    | Kimai environment name                               | `prod`                            |
-| `kimaiAppSecret`      | Secret used to encrypt session cookies               | `change_this_to_something_unique` |
-| `kimaiAdminEmail`     | Email for the superadmin account                     | ``                                |
-| `kimaiAdminPassword`  | Password for the superadmin account                  | ``                                |
-| `kimaiMailerFrom`     | Application specific “from” address for all emails   | `kimai@example.com`               |
-| `kimaiMailerUrl`      | SMTP connection for emails                           | `null://localhost`                |
-| `kimaiTrustedProxies` |                                                      | `""`                              |
-| `existingSecret`      | Name of existing secret containing Kimai credentials | `""`                              |
+| Name                      | Description                                                                | Value                             |
+|---------------------------|----------------------------------------------------------------------------|-----------------------------------|
+| `kimaiEnvironment`        | Kimai environment name                                                     | `prod`                            |
+| `kimaiAppSecret`          | Secret used to encrypt session cookies                                     | `change_this_to_something_unique` |
+| `kimaiAdminEmail`         | Email for the superadmin account                                           | ``                                |
+| `kimaiAdminPassword`      | Password for the superadmin account                                        | ``                                |
+| `kimaiMailerFrom`         | Application specific “from” address for all emails                         | `kimai@example.com`               |
+| `kimaiMailerUrl`          | SMTP connection for emails                                                 | `null://localhost`                |
+| `kimaiTrustedProxies`     |                                                                            | `""`                              |
+| `existingSecret`          | Name of existing secret containing Kimai credentials                       | `""`                              |
+| `configurationFromSecret` | Use secret kimai2-config containing “local.yaml“ key as configuration file | `""`                              |
 
 ### Kimai deployment parameters
 

--- a/charts/kimai2/templates/deployment.yaml
+++ b/charts/kimai2/templates/deployment.yaml
@@ -200,11 +200,16 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
-        {{- if .Values.configuration }}
+        {{- if and .Values.configuration (not .Values.configurationFromSecret.enabled) }}
         - name: config
           configMap:
             name: {{ printf "%s-config" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
             defaultMode: 0555
+        {{- end }}
+        {{- if .Values.configurationFromSecret.enabled}}
+        - name: config
+          secret:
+            secretName: {{ include "kimai2.name" . }}-config
         {{- end }}
         - name: kimai-data
           {{- if .Values.persistence.enabled }}

--- a/charts/kimai2/templates/deployment.yaml
+++ b/charts/kimai2/templates/deployment.yaml
@@ -209,7 +209,7 @@ spec:
         {{- if .Values.configurationFromSecret.enabled}}
         - name: config
           secret:
-            secretName: {{ include "kimai2.name" . }}-config
+            secretName: {{ printf "%s-config" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
         {{- end }}
         - name: kimai-data
           {{- if .Values.persistence.enabled }}

--- a/charts/kimai2/values.yaml
+++ b/charts/kimai2/values.yaml
@@ -129,7 +129,7 @@ existingSecret: ""
 
 configurationFromSecret:
   ## @param configurationFromSecret.enabled Enables Kimai configuration retrieval from secret
-  ## If set to "true", secret name has to be "kimai2-config" and contain a "local.yaml" key
+  ## When the value is set to 'true', the secret name must match the common.names.fullname template and include a 'local.yaml' key.
   enabled: false
 
 ## @param command Override default container command (useful when using custom images)

--- a/charts/kimai2/values.yaml
+++ b/charts/kimai2/values.yaml
@@ -127,6 +127,11 @@ kimaiTrustedProxies: ""
 ##
 existingSecret: ""
 
+configurationFromSecret:
+  ## @param configurationFromSecret.enabled Enables Kimai configuration retrieval from secret
+  ## If set to "true", secret name has to be "kimai2-config" and contain a "local.yaml" key
+  enabled: false
+
 ## @param command Override default container command (useful when using custom images)
 ##
 command: []


### PR DESCRIPTION
This introduces the capability to reference an existing secret to retrieve the Kimai configuration from.

The primary motivation for this feature is to enable the inclusion of sensitive data within the Kimai configuration. For instance, in my scenario, I'm using SAML for authentication, which requires my configuration to contain a x509 certificate. 

Below is an example of the secret used as configuration :

```
monolog:
    handlers:
        main:
            path: php://stderr
kimai:
    saml:
        provider: keycloak
        activate: true
        title: Keycloak
        mapping:
            - { saml: $Email, kimai: email }
            - { saml: $FirstName $LastName, kimai: alias }
        roles:
            resetOnLogin: true
            attribute: Roles
            mapping:
                - { saml: kimai-superadmins, kimai: ROLE_ADMIN }
                - { saml: kimai-users, kimai: ROLE_TEAMLEAD }
        connection:
            # You SAML provider, here an example for Keycloak
            idp:
                entityId: 'https://sso.mycompany.net/realms/mycompany'
                singleSignOnService:
                    url: 'https://sso.mycompany.net/realms/mycompany/protocol/saml'
                    binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                x509cert: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
            sp:
                entityId: 'kimai'
                assertionConsumerService:
                    url: 'https://kimai.mycompany.net/auth/saml/acs'
                    binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
                singleLogoutService:
                    url: 'https://kimai.mycompany.net/auth/saml/logout'
                    binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
            baseurl: 'https://kimai.mycompany.net/auth/saml/'
            strict: true
            debug: true
            security:
                nameIdEncrypted: false
                authnRequestsSigned: false
                logoutRequestSigned: false
                logoutResponseSigned: false
                wantMessagesSigned: false
                wantAssertionsSigned: false
                wantNameIdEncrypted: false
                requestedAuthnContext: true
                signMetadata: false
                wantXMLValidation: true
                signatureAlgorithm: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
                digestAlgorithm: 'http://www.w3.org/2001/04/xmlenc#sha256'
            contactPerson:
                technical:
                    givenName: 'Kimai Admin'
                    emailAddress: 'admin@mycompany.net'
                support:
                    givenName: 'Kimai Support'
                    emailAddress: 'tech@mycompany.net'
            organization:
                en:
                    name: 'Mycompany'
                    displayname: 'Mycompany'
                    url: 'https://kimai.mycompany.net'
```