### PR TITLE
Added option to specify threads in update job

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.9.2
+version: 3.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nominatim/README.md
+++ b/charts/nominatim/README.md
@@ -134,10 +134,11 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Nominatim Replication Configuration parameters
 
-| Name                                       | Description                     | Value                |
-| ------------------------------------------ | ------------------------------- | -------------------- |
-| `nominatimReplications.enabled`            | enable/disable replication      | `false `             |
-| `nominatimReplications.replicationUrl`     | URL with update information     | `https://download.geofabrik.de/europe/germany/sachsen-updates/` |
+| Name                                   | Description                 | Value                                                           |
+|----------------------------------------|-----------------------------|-----------------------------------------------------------------|
+| `nominatimReplications.enabled`        | enable/disable replication  | `false `                                                        |
+| `nominatimReplications.replicationUrl` | URL with update information | `https://download.geofabrik.de/europe/germany/sachsen-updates/` |
+| `nominatimReplications.threads`        | Amount of threads to use    | `1`                                                             |
 
 ### Nominatim deployment parameters
 

--- a/charts/nominatim/README.md
+++ b/charts/nominatim/README.md
@@ -134,11 +134,12 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Nominatim Replication Configuration parameters
 
-| Name                                   | Description                 | Value                                                           |
-|----------------------------------------|-----------------------------|-----------------------------------------------------------------|
-| `nominatimReplications.enabled`        | enable/disable replication  | `false `                                                        |
-| `nominatimReplications.replicationUrl` | URL with update information | `https://download.geofabrik.de/europe/germany/sachsen-updates/` |
-| `nominatimReplications.threads`        | Amount of threads to use    | `1`                                                             |
+| Name                                   | Description                                             | Value                                                           |
+|----------------------------------------|---------------------------------------------------------|-----------------------------------------------------------------|
+| `nominatimReplications.enabled`        | enable/disable replication                              | `false `                                                        |
+| `nominatimReplications.replicationUrl` | URL with update information                             | `https://download.geofabrik.de/europe/germany/sachsen-updates/` |
+| `nominatimReplications.resources`      | Define resources requests and limits for the update job | `{}`                                                            |
+| `nominatimReplications.threads`        | Amount of threads to use                                | `1`                                                             |
 
 ### Nominatim deployment parameters
 

--- a/charts/nominatim/templates/updateJob.yaml
+++ b/charts/nominatim/templates/updateJob.yaml
@@ -42,8 +42,11 @@ spec:
             {{- include "common.tplvalues.render" (dict "value" .Values.nominatim.extraEnv "context" $) | nindent 12 }}
           {{- end }}
           command:
-            - nominatim
-            - replication
+            - /bin/bash
+            - -ec
+            - |
+                nominatim replication --check-for-updates
+                nominatim replication --threads {{ .Values.nominatimReplications.threads }}
           volumeMounts:
             - mountPath: /dev/shm
               name: dshm

--- a/charts/nominatim/templates/updateJob.yaml
+++ b/charts/nominatim/templates/updateJob.yaml
@@ -54,6 +54,10 @@ spec:
             - mountPath: /nominatim/flatnode
               name: nominatim
               subPath: flatnode
+            {{- end }}
+          {{- if .Values.nominatimReplications.resources }}
+          resources:
+            {{- toYaml .Values.nominatimReplications.resources | nindent 12 }}
           {{- end }}
       restartPolicy: Always
       {{- with .Values.nodeSelector }}

--- a/charts/nominatim/templates/updateJob.yaml
+++ b/charts/nominatim/templates/updateJob.yaml
@@ -45,7 +45,6 @@ spec:
             - /bin/bash
             - -ec
             - |
-                nominatim replication --check-for-updates
                 nominatim replication --threads {{ .Values.nominatimReplications.threads }}
           volumeMounts:
             - mountPath: /dev/shm

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -65,7 +65,8 @@ nominatimInitialize:
 #      memory: 4Gi
 
 nominatimReplications:
-  enabled: false
+  enabled: true
+  threads: 1
   replicationUrl: https://download.geofabrik.de/europe/germany/sachsen-updates/
 
 nominatim:

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -66,8 +66,21 @@ nominatimInitialize:
 
 nominatimReplications:
   enabled: true
-  threads: 1
   replicationUrl: https://download.geofabrik.de/europe/germany/sachsen-updates/
+  threads: 1
+
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  resources: {}
+#    requests:
+#      cpu: 2000m
+#      memory: 2Gi
+#    limits:
+#      cpu: 2000m
+#      memory: 2Gi
+
 
 nominatim:
   extraEnv: []

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -65,7 +65,7 @@ nominatimInitialize:
 #      memory: 4Gi
 
 nominatimReplications:
-  enabled: true
+  enabled: false
   replicationUrl: https://download.geofabrik.de/europe/germany/sachsen-updates/
   threads: 1
 


### PR DESCRIPTION
The `--threads` parameter on `nominatiom replication` helps us to drastically speed up the replication process on multi-cpu machines. Hence, I also added an option to customizie the update-job hardware resources on the cluster.