### PR TITLE
fix: Wait for db does not work on arm64

### DIFF
--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -12,9 +12,15 @@ spec:
         fsGroup: 2000
       initContainers:
         - name: wait-for-db
-          image: willwill/wait-for-it
+          image: postgres
           args:
-            - {{ include "nominatim.databaseHost" . }}:{{ include "nominatim.databasePort" . }}
+            - /bin/bash
+            - -c
+            - |
+              until pg_isready -h {{ include "nominatim.databaseHost" . }} -p {{ include "nominatim.databasePort" . }} -U {{ include "nominatim.databaseUser" . }}; do
+                echo "Waiting for database..."
+                sleep 2
+              done
 
 {{- if .Values.nominatimInitialize.customStyleUrl }}
         - name: download-custom-style


### PR DESCRIPTION
The current wait-for-it image is not compiled for arm64. A solution would be to use postgres to wait for the db