### PR TITLE
nominatim: use tolerations definition for init job

### DIFF
--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -183,6 +183,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if  .Values.flatnode.enabled }}
         - name: flatnode


### PR DESCRIPTION
Hi @robjuz,

currently, the `tolerations` setting is only used for the running temployment but not for the init job. However, using the tolerations for the init job can be especially useful if (as in my case) very powerful machines are tainted to be reserved for resource intensive tasks (e.g., database migrations, imports, etc...). So it would be great if the tolerations will also be used for the init job.

Best regards
Matthias