### PR TITLE
[Kimai] Bump some versions and an image

### DIFF
--- a/charts/kimai2/Chart.yaml
+++ b/charts/kimai2/Chart.yaml
@@ -2,18 +2,18 @@ apiVersion: v2
 name: kimai2
 description: A Helm chart for Kubernetes
 type: application
-version: 4.3.3
+version: 4.4.0
 appVersion: "apache-2.29.0"
 
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 11.5.7
+    version: 20.x.x
   - condition: redis.enabled
     name: redis
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 19.5.0
+    version: 20.x.x
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
     tags:

--- a/charts/kimai2/values.yaml
+++ b/charts/kimai2/values.yaml
@@ -652,8 +652,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: 11-debian-11-r112
+    repository: bitnami/os-shell
+    tag: 12-debian-12-r36
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
* Updated MariaDB to 20.x.x
* Updated redis to 20.x.x
* Changed the `bitnami-shell` image to `os-shell`. `bitnami-shell` isn't maintained anymore.

JFI: The 2.29.0 Image wasn't build at the moment. So the update of kimai will fail.