### PR TITLE
downgrade to 2.28 because 2.29 is not found on dockerhub registry

### DIFF
--- a/charts/kimai2/Chart.yaml
+++ b/charts/kimai2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kimai2
 description: A Helm chart for Kubernetes
 type: application
-version: 4.3.3
+version: 4.3.4
 appVersion: "apache-2.28.0"
 
 dependencies:

--- a/charts/kimai2/Chart.yaml
+++ b/charts/kimai2/Chart.yaml
@@ -3,7 +3,7 @@ name: kimai2
 description: A Helm chart for Kubernetes
 type: application
 version: 4.3.3
-appVersion: "apache-2.29.0"
+appVersion: "apache-2.28.0"
 
 dependencies:
   - condition: mariadb.enabled

--- a/charts/kimai2/values.yaml
+++ b/charts/kimai2/values.yaml
@@ -26,7 +26,7 @@ kubeVersion: ""
 ## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
 ##
 nameOverride: ""
-## @param fullnameOverride String to fully override common.names.fullname template
+## @param fullnameOverride String to fully override common.names.fullname templatekimai
 ##
 fullnameOverride: ""
 ## @param commonLabels Labels to add to all deployed resources
@@ -73,7 +73,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: kimai/kimai2
-  tag: apache-2.29.0
+  tag: apache-2.28.0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
New chart version keeps failing because the 2.29 is not found on docker hub