### PR TITLE
Nominatim: exclude jobs from pbd selector

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.1.0
+version: 5.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nominatim/templates/pdb.yaml
+++ b/charts/nominatim/templates/pdb.yaml
@@ -17,5 +17,11 @@ spec:
   {{- end }}
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
+    {{- if .Values.pdb.pdbMatchExpressions }}
+    matchExpressions:
+      {{- with (.Values.pdb.pdbMatchExpressions) }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
 {{- end }}

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -1018,11 +1018,16 @@ serviceAccount:
 ## @param pdb.create Enable a Pod Disruption Budget creation
 ## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
 ## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
+## @param pdb.pdbMatchExpressions MatchExpressions for the pdb selector. Excludes job object by default
 ##
 pdb:
   create: false
   minAvailable: 1
   maxUnavailable: ""
+  pdbMatchExpressions:
+    - key: job-name
+      operator: DoesNotExist
+
 ## Nominatim Autoscaling configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 ## @param autoscaling.enabled Enable Horizontal POD autoscaling for Nominatim


### PR DESCRIPTION
This PR excludes job resource from the nominatim PDB selector.
 
The update job resource and the deployment use the same common labels and therefore jobs are selected as targets for the PDB. This PR adds `pdbMatchExpressions` param that by default is set to exclude resources that have `job-name` key in labels.

How did I find this: At work we have deployed nominatim with ArgoCD, and once I configured the update job to run, the Argo app status changed to Degraded due to the PDB throwing `Failed to calculate the number of expected pods: jobs.batch does not implement the scale subresource`.

Tested with the default values, no pdbMatchExpressions list provided, and with empty pdbMatchExpressions list.

I have also checked if there's a function in bitnami common that I can use akin to the way labels are set, but I haven't found anything.