### PR TITLE
Change external database port to server version

### DIFF
--- a/charts/kimai2/templates/_helpers.tpl
+++ b/charts/kimai2/templates/_helpers.tpl
@@ -97,7 +97,7 @@ Return the Database ServerVersion
 {{- if .Values.mariadb.enabled }}
     {{- printf "%s" (regexReplaceAll "-.*$" .Values.mariadb.image.tag "") -}}
 {{- else -}}
-    {{- printf "%s" (.Values.externalDatabase.serverVersion) -}}
+    {{- .Values.externalDatabase.serverVersion -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
The helm chart allows the definition of an externalDatabase, but the logic for creating the url is faulty. For server version, the port is used:
```yaml
{{- if .Values.mariadb.enabled }}
    {{- printf "%s" (regexReplaceAll "-.*$" .Values.mariadb.image.tag "") -}}
{{- else -}}
    {{- printf "%d" (.Values.externalDatabase.port | int ) -}}
{{- end -}}
{{- end -}}
```

Instead, we should use the already present `serverVersion` field from the values, to populate this field:
```yaml
## External Database Configuration
## All of these values are only used if `mariadb.enabled=false`
##
externalDatabase:
  ...
  ## @param externalDatabase.serverVersion External Database server version
  ##
  serverVersion: "5.7"
```

This PR fixes this issue