### PR TITLE
updated kimai to 2.44 and fixed TRUSTED_HOSTS delimiter

### DIFF
--- a/charts/kimai2/Chart.yaml
+++ b/charts/kimai2/Chart.yaml
@@ -3,7 +3,7 @@ name: kimai2
 description: A Helm chart for Kubernetes
 type: application
 version: 4.3.11
-appVersion: "apache-2.40.0"
+appVersion: "apache-2.44.0"
 
 dependencies:
   - condition: mariadb.enabled

--- a/charts/kimai2/templates/deployment.yaml
+++ b/charts/kimai2/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
                   name: {{ include "kimai.secretName" . }}
                   key: database-url
             - name: TRUSTED_HOSTS
-              value: localhost,{{ .Values.ingress.hostname }}
+              value: localhost|{{ .Values.ingress.hostname }}
             {{- if .Values.kimaiTrustedProxies }}
             - name: TRUSTED_PROXIES
               value: {{ .Values.kimaiTrustedProxies }}

--- a/charts/kimai2/values.yaml
+++ b/charts/kimai2/values.yaml
@@ -75,7 +75,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: kimai/kimai2
-  tag: apache-2.40.0
+  tag: apache-2.44.0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
TRUSTED_HOSTS is a regex so the delimiter should be `|` and not `,`. Ref: https://github.com/kimai/kimai/issues/5693