### PR TITLE
fix(nominatim): wrap admin --warm with required timeouts + expose as initJob.warm.* values (closes #199)

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.1.0
+version: 6.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.1.1
+version: 6.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -238,7 +238,14 @@ spec:
 
               echo "Import job done. Warming up database indices."
 
-              nominatim admin --warm
+              # `nominatim admin --warm` requires explicit timeout overrides since
+              # Nominatim 5.2.0 (asyncio TimeoutError on Planet imports). Mirrors
+              # the official mediagis/nominatim-docker init.sh wrapper. The `|| true`
+              # is defensive: warming is best-effort, no need to fail a multi-day
+              # import over a non-blocking cache preload.
+              # See: https://github.com/robjuz/helm-charts/issues/199
+              NOMINATIM_QUERY_TIMEOUT=600 NOMINATIM_REQUEST_TIMEOUT=3600 \
+                nominatim admin --warm || echo "WARN: warm exited non-zero, continuing"
 
               echo "Warming finished."
               date "+%Y-%m-%d %H:%M:%S"

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -236,18 +236,23 @@ spec:
                 fi
               fi;
 
+              {{- if .Values.initJob.warm.enabled }}
               echo "Import job done. Warming up database indices."
 
               # `nominatim admin --warm` requires explicit timeout overrides since
               # Nominatim 5.2.0 (asyncio TimeoutError on Planet imports). Mirrors
-              # the official mediagis/nominatim-docker init.sh wrapper. The `|| true`
+              # the official mediagis/nominatim-docker init.sh wrapper. The `|| echo`
               # is defensive: warming is best-effort, no need to fail a multi-day
               # import over a non-blocking cache preload.
               # See: https://github.com/robjuz/helm-charts/issues/199
-              NOMINATIM_QUERY_TIMEOUT=600 NOMINATIM_REQUEST_TIMEOUT=3600 \
+              NOMINATIM_QUERY_TIMEOUT={{ .Values.initJob.warm.queryTimeout }} \
+              NOMINATIM_REQUEST_TIMEOUT={{ .Values.initJob.warm.requestTimeout }} \
                 nominatim admin --warm || echo "WARN: warm exited non-zero, continuing"
 
               echo "Warming finished."
+              {{- else }}
+              echo "Skipping warm step (initJob.warm.enabled=false). Database will warm naturally on first queries."
+              {{- end }}
               date "+%Y-%m-%d %H:%M:%S"
               # show import duration in days, hours and minutes
               duration=$SECONDS

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -591,6 +591,28 @@ initJob:
   freeze: false
   wikipediaUrl: https://nominatim.org/data/wikimedia-importance.sql.gz
 
+  ## Warm-up step (`nominatim admin --warm`) configuration.
+  ## Since Nominatim 5.2.0, the warm step requires explicit timeout overrides
+  ## to avoid an asyncio TimeoutError on large imports (notably Planet OSM).
+  ## Defaults mirror the official mediagis/nominatim-docker init.sh wrapper.
+  ## See: https://github.com/robjuz/helm-charts/issues/199
+  warm:
+    ## @param initJob.warm.enabled Whether to run `nominatim admin --warm` after import.
+    ## Disabling skips the cache preload entirely; the database will warm naturally
+    ## on first user queries. Useful when warm consistently times out and warming
+    ## via HTTP requests on the running service is preferred.
+    ##
+    enabled: true
+    ## @param initJob.warm.queryTimeout Value of NOMINATIM_QUERY_TIMEOUT during warm.
+    ## Bound to the per-query asyncio timeout in nominatim_api.
+    ##
+    queryTimeout: 600
+    ## @param initJob.warm.requestTimeout Value of NOMINATIM_REQUEST_TIMEOUT during warm.
+    ## This is the variable that actually controls the timeout that fires on Planet
+    ## imports; the default of 60s in env.defaults is too short for cold-cache warm.
+    ##
+    requestTimeout: 3600
+
   ## @param initJob.continue Nominatim import CLI continue arg
   ## If undefined (default) `--continue` flag is not set on nominatim import
   ## If defined, `nominatim import --continue <step>` is set


### PR DESCRIPTION
## Summary

Fixes the `nominatim admin --warm` step in the init Job that has been crashing on Planet OSM imports since the chart bumped to `mediagis/nominatim:5.2.0`, and exposes the warm-step configuration as Helm values.

The fix wraps the warm call with `NOMINATIM_QUERY_TIMEOUT=600` and `NOMINATIM_REQUEST_TIMEOUT=3600` (the same overrides as the [official `mediagis/nominatim-docker` `init.sh`](https://github.com/mediagis/nominatim-docker/blob/release/v5.2/init.sh)). A defensive `|| echo` is added so the multi-day Job is not failed by a non-blocking cache preload.

The hardcoded values are then promoted to chart values so operators can disable warm entirely or tune timeouts without forking.

Closes #199

## Why

Nominatim 5.2.0 [restructured the forward query parser](https://github.com/osm-search/Nominatim/releases/tag/v5.2.0) and added a new `timeout.py` module. The default `NOMINATIM_REQUEST_TIMEOUT` of 60s now binds `nominatim admin --warm`, which is too short for the cold-cache first query on Planet-sized DBs.

The chart's inline command in `templates/initJob.yaml` bypassed the official mediagis wrapper's timeout overrides, so even users injecting `extraEnvVars` (the #163 fix) hit the asyncio `TimeoutError`.

## Validation

Tested on a real Planet OSM deployment with a freshly-imported 1 TB DB:

| Scenario | Result |
|----------|--------|
| Without fix, `NOMINATIM_QUERY_TIMEOUT=43200` via `extraEnvVars` (12h) | ❌ Crashes in 4-10 min with `asyncio.TimeoutError` |
| With fix (`QUERY_TIMEOUT=600` + `REQUEST_TIMEOUT=3600`) | ✅ Completes in ~27 min |

The crucial variable is `NOMINATIM_REQUEST_TIMEOUT`, not `NOMINATIM_QUERY_TIMEOUT` (which is why the existing `extraEnvVars` workaround alone wasn't enough).

## Changes

### `charts/nominatim/templates/initJob.yaml`

- Wrap `nominatim admin --warm` with the timeout overrides + defensive `|| echo`
- Make the warm step opt-out via a new `initJob.warm.enabled` flag

### `charts/nominatim/values.yaml`

New `initJob.warm.*` block:

```yaml
initJob:
  warm:
    enabled: true        # set to false to skip warm entirely
    queryTimeout: 600    # NOMINATIM_QUERY_TIMEOUT during warm
    requestTimeout: 3600 # NOMINATIM_REQUEST_TIMEOUT during warm
```

### `charts/nominatim/Chart.yaml`

- Bump `version` from `6.1.0` to `6.2.0` (minor: new chart options, no breaking change, defaults preserve existing behavior)

## Use cases unlocked

- **Planet OSM operators**: defaults work out of the box (was broken before).
- **Region operators (e.g. France-only imports)**: can set `warm.enabled: false` when warming via the running service is preferred over the in-Job preload.
- **Heavy/slow setups**: can bump `queryTimeout` / `requestTimeout` without forking.
- **Existing users on smaller datasets**: no change, defaults match what was running before.

## Notes

- No breaking change. Defaults match the (now broken) prior behavior on small datasets, fix the broken behavior on large datasets.
- Validated against `mediagis/nominatim:5.2.0`.
- The `|| echo "WARN: ..."` is intentional: warming is best-effort, and on extra-cold databases even bumped timeouts can be tight. A failed warm is recoverable (the DB warms naturally on first queries); a failed multi-day import Job is not.

Happy to address any review feedback.
