### PR TITLE
nominatim: add database migration job

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.1.0
+version: 6.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nominatim/README.md
+++ b/charts/nominatim/README.md
@@ -224,6 +224,36 @@ Note: The command above may differ a little depending the k8s cluster version yo
 | `initJob.extraEnvVarsCM`            | Name of existing ConfigMap containing extra env vars                                                                                                                                                              | `""`                                                |
 | `initJob.extraEnvVarsSecret`        | Name of existing Secret containing extra env vars                                                                                                                                                                 | `""`                                                |
 
+### Nominatim Migration Job parameters
+
+| Name                                                          | Description                                                                                                                                                                                                      | Value            |
+|---------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
+| `migrateJob.enabled`                                          | Run a post-install/post-upgrade hook Job migrating the database schema. Ignored when `initJob.enabled` is set                                                                                                     | `true`           |
+| `migrateJob.dbWaitTimeout`                                    | The number of seconds to wait for the DB to be ready to accept connections                                                                                                                                       | `300`            |
+| `migrateJob.backoffLimit`                                     | Set backoff limit of the job                                                                                                                                                                                     | `1`              |
+| `migrateJob.activeDeadlineSeconds`                            | Set the duration in seconds the job may be active before the system tries to terminate it                                                                                                                        | `""`             |
+| `migrateJob.ttlSecondsAfterFinished`                          | Set the number of seconds a finished job is kept before being deleted                                                                                                                                            | `""`             |
+| `migrateJob.annotations`                                      | Add annotations to the job                                                                                                                                                                                       | `{}`             |
+| `migrateJob.podLabels`                                        | Additional pod labels                                                                                                                                                                                            | `{}`             |
+| `migrateJob.podAnnotations`                                   | Additional pod annotations                                                                                                                                                                                       | `{}`             |
+| `migrateJob.nodeSelector`                                     | Node labels for pod assignment                                                                                                                                                                                   | `{}`             |
+| `migrateJob.tolerations`                                      | Tolerations for pod assignment                                                                                                                                                                                   | `[]`             |
+| `migrateJob.podSecurityContext.enabled`                       | Enabled Nominatim Migration pods' Security Context                                                                                                                                                               | `true`           |
+| `migrateJob.podSecurityContext.fsGroup`                       | Set Nominatim Migration pod's Security Context fsGroup                                                                                                                                                           | `101`            |
+| `migrateJob.podSecurityContext.seccompProfile.type`           | Set Nominatim Migration container's Security Context seccomp profile                                                                                                                                             | `RuntimeDefault` |
+| `migrateJob.containerSecurityContext.enabled`                 | Enabled Nominatim Migration containers' Security Context                                                                                                                                                         | `false`          |
+| `migrateJob.containerSecurityContext.runAsUser`               | Set Nominatim Migration container's Security Context runAsUser                                                                                                                                                   | `1001`           |
+| `migrateJob.containerSecurityContext.runAsNonRoot`            | Set Nominatim Migration container's Security Context runAsNonRoot                                                                                                                                                | `true`           |
+| `migrateJob.containerSecurityContext.allowPrivilegeEscalation` | Set Nominatim Migration container's privilege escalation                                                                                                                                                        | `false`          |
+| `migrateJob.containerSecurityContext.capabilities.drop`       | Set Nominatim Migration container's Security Context capabilities to drop                                                                                                                                        | `["ALL"]`        |
+| `migrateJob.extraEnvVars`                                     | Array with extra environment variables to add to the Nominatim container                                                                                                                                         | `[]`             |
+| `migrateJob.extraEnvVarsCM`                                   | Name of existing ConfigMap containing extra env vars                                                                                                                                                             | `""`             |
+| `migrateJob.extraEnvVarsSecret`                               | Name of existing Secret containing extra env vars                                                                                                                                                                | `""`             |
+| `migrateJob.extraVolumes`                                     | Optionally specify extra list of additional volumes for the Nominatim migration pod                                                                                                                              | `[]`             |
+| `migrateJob.extraVolumeMounts`                                | Optionally specify extra list of additional volumeMounts for the Nominatim migration container                                                                                                                   | `[]`             |
+| `migrateJob.resourcesPreset`                                  | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `micro`          |
+| `migrateJob.resources`                                        | Set container requests and limits for different resources like CPU or memory (essential for production workloads)                                                                                                | `{}`             |
+
 ### Nominatim Updates Configuration parameters
 | Name                         | Description                                                              | Value                                                           |
 |------------------------------|--------------------------------------------------------------------------|-----------------------------------------------------------------|
@@ -474,6 +504,18 @@ Using flatnode with replication enabled requires the usage of a ReadWriteMany vo
 be shared within the pods.
 This also applies when scaling the nominatim deployment.
 
+### Database migration
+
+Whenever the Nominatim version changes, the database schema has to be migrated. The chart does this for you with a
+`post-install`/`post-upgrade` hook Job running `nominatim admin --migrate`, so a GitOps flow like ArgoCD (which maps the
+hook to a `PostSync` resource) picks up the migration without a manual step.
+
+The job is a no-op when there is nothing to do: it exits successfully when the database is already at the version of the
+deployed release, and also when no Nominatim database exists yet. It is skipped entirely while `initJob.enabled` is set,
+because during the initialisation phase the database is built from scratch anyway.
+
+Set `migrateJob.enabled: false` to opt out and migrate manually.
+
 ### PVC For data
 
 When importing large extracts (Europe/Planet) the data needed to be downloaded are quite big. If your server has not
@@ -567,6 +609,11 @@ The chart also facilitates the creation of TLS secrets for use with the Ingress 
 certificate management.
 
 ## Upgrading
+
+### To 6.2.0
+
+This release adds the database migration job, which is enabled by default. From now on every `helm upgrade` runs
+`nominatim admin --migrate` against the database. Set `migrateJob.enabled: false` to keep migrating manually.
 
 ### To 6.0.0
 

--- a/charts/nominatim/templates/migrateJob.yaml
+++ b/charts/nominatim/templates/migrateJob.yaml
@@ -1,0 +1,155 @@
+{{- if and .Values.migrateJob.enabled (not .Values.initJob.enabled) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-migrate" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: nominatim
+    app.kubernetes.io/component: migrate
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.migrateJob.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.migrateJob.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.migrateJob.backoffLimit }}
+  {{- if .Values.migrateJob.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.migrateJob.activeDeadlineSeconds }}
+  {{- end }}
+  {{- if .Values.migrateJob.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.migrateJob.ttlSecondsAfterFinished }}
+  {{- end }}
+  template:
+    metadata:
+      {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.migrateJob.podLabels .Values.commonLabels ) "context" . ) }}
+      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
+        app.kubernetes.io/part-of: nominatim
+        app.kubernetes.io/component: migrate
+      {{- if .Values.migrateJob.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.migrateJob.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "nominatim.imagePullSecrets" . | nindent 6 }}
+      restartPolicy: Never
+      serviceAccountName: {{ include "nominatim.serviceAccountName" . }}
+      {{- if .Values.migrateJob.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.migrateJob.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.migrateJob.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.migrateJob.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.migrateJob.podSecurityContext.enabled }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.migrateJob.podSecurityContext "context" $) | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: nominatim-migrate
+          image: {{ include "nominatim.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          workingDir: /nominatim
+          {{- if .Values.migrateJob.containerSecurityContext.enabled }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.migrateJob.containerSecurityContext "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: NOMINATIM_DATABASE_DSN
+              {{- if .Values.externalDatabase.existingSecretDsn }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalDatabase.existingSecretDsn }}
+                  key: {{ .Values.externalDatabase.existingSecretDsnKey }}
+              {{- else }}
+              value: {{ include "nominatim.databaseDSN" . }}
+              {{- end }}
+            - name: NOMINATIM_IMPORT_STYLE
+              value: {{ .Values.initJob.importStyle }}
+            {{- if .Values.flatnode.enabled }}
+            - name: NOMINATIM_FLATNODE_FILE
+              value: /nominatim/flatnode/flatnode.file
+            {{- end }}
+            - name: DB_WAIT_TIMEOUT
+              value: {{ .Values.migrateJob.dbWaitTimeout | quote }}
+            {{- if .Values.migrateJob.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.migrateJob.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.migrateJob.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.migrateJob.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.migrateJob.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.migrateJob.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              CONNECTION_STRING="${NOMINATIM_DATABASE_DSN#pgsql:}"
+
+              export PGDATABASE=$(echo "$CONNECTION_STRING" | grep -o 'dbname=[^;]*' | cut -d= -f2)
+              export PGHOST=$(echo "$CONNECTION_STRING" | grep -o 'host=[^;]*' | cut -d= -f2)
+              export PGPORT=$(echo "$CONNECTION_STRING" | grep -o 'port=[^;]*' | cut -d= -f2)
+              export PGUSER=$(echo "$CONNECTION_STRING" | grep -o 'user=[^;]*' | cut -d= -f2)
+              export PGPASSWORD=$(echo "$CONNECTION_STRING" | grep -o 'password=[^;]*' | cut -d= -f2)
+
+              echo "Waiting for PostgreSQL at ${PGHOST}:${PGPORT}..."
+              start_time=$(date +%s)
+              until pg_isready -q; do
+                elapsed_time=$(( $(date +%s) - start_time ))
+                if [ $elapsed_time -ge $DB_WAIT_TIMEOUT ]; then
+                  echo "ERROR: Timeout reached after ${DB_WAIT_TIMEOUT} seconds. Database at ${PGHOST}:${PGPORT} is not ready."
+                  exit 1
+                fi
+                sleep 2
+              done
+
+              if ! NOMINATIM_SCHEMA=$(psql -tAc "SELECT to_regclass('public.nominatim_properties')"); then
+                echo "ERROR: Could not query ${PGDATABASE} at ${PGHOST}:${PGPORT}."
+                exit 1
+              fi
+
+              if [ -z "$NOMINATIM_SCHEMA" ]; then
+                echo "No Nominatim database found in ${PGDATABASE}. Nothing to migrate."
+                exit 0
+              fi
+
+              nominatim admin --migrate
+          {{- end }}
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+            {{- if .Values.flatnode.enabled }}
+            - mountPath: /nominatim/flatnode
+              name: nominatim
+              subPath: flatnode
+            {{- end }}
+            {{- if .Values.migrateJob.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.migrateJob.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
+          {{- if .Values.migrateJob.resources }}
+          resources: {{- toYaml .Values.migrateJob.resources | nindent 12 }}
+          {{- else if ne .Values.migrateJob.resourcesPreset "none" }}
+          resources: {{- include "common.resources.preset" (dict "type" .Values.migrateJob.resourcesPreset) | nindent 12 }}
+          {{- end }}
+      volumes:
+        {{- if .Values.flatnode.enabled }}
+        - name: nominatim
+          persistentVolumeClaim:
+            claimName: {{ .Values.flatnode.existingClaim | default (include "common.names.fullname" .) }}
+        {{- end }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+        {{- if .Values.migrateJob.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.migrateJob.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -705,6 +705,99 @@ initJob:
   #      cpu: 4000m
   #      memory: 4Gi
 
+## Database migration job, run as a Helm post-install/post-upgrade hook
+## It runs `nominatim admin --migrate`, which is a no-op when the database is already
+## at the version of the deployed Nominatim release
+## ref: https://nominatim.org/release-docs/latest/admin/Migration/
+##
+migrateJob:
+  ## @param migrateJob.enabled Run a post-install/post-upgrade hook Job migrating the database schema. Ignored when `initJob.enabled` is set
+  ##
+  enabled: true
+  ## @param migrateJob.dbWaitTimeout The number of seconds to wait for the DB to be ready to accept connections
+  ##
+  dbWaitTimeout: 300
+  ## @param migrateJob.backoffLimit Set backoff limit of the job
+  ##
+  backoffLimit: 1
+  ## @param migrateJob.activeDeadlineSeconds Set the duration in seconds the job may be active before the system tries to terminate it
+  ##
+  activeDeadlineSeconds: ""
+  ## @param migrateJob.ttlSecondsAfterFinished Set the number of seconds a finished job is kept before being deleted
+  ##
+  ttlSecondsAfterFinished: ""
+  ## @param migrateJob.annotations [object] Add annotations to the job
+  ##
+  annotations: {}
+  ## @param migrateJob.podLabels Additional pod labels
+  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param migrateJob.podAnnotations Additional pod annotations
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param migrateJob.nodeSelector Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param migrateJob.tolerations Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  ## Configure Pods Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param migrateJob.podSecurityContext.enabled Enabled Nominatim Migration pods' Security Context
+  ## @param migrateJob.podSecurityContext.fsGroup Set Nominatim Migration pod's Security Context fsGroup
+  ## @param migrateJob.podSecurityContext.seccompProfile.type Set Nominatim Migration container's Security Context seccomp profile
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroup: 101
+    seccompProfile:
+      type: "RuntimeDefault"
+  ## Configure Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param migrateJob.containerSecurityContext.enabled Enabled Nominatim Migration containers' Security Context
+  ## @param migrateJob.containerSecurityContext.runAsUser Set Nominatim Migration container's Security Context runAsUser
+  ## @param migrateJob.containerSecurityContext.runAsNonRoot Set Nominatim Migration container's Security Context runAsNonRoot
+  ## @param migrateJob.containerSecurityContext.allowPrivilegeEscalation Set Nominatim Migration container's privilege escalation
+  ## @param migrateJob.containerSecurityContext.capabilities.drop Set Nominatim Migration container's Security Context runAsNonRoot
+  ##
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+  ## @param migrateJob.extraEnvVars Array with extra environment variables to add to the Nominatim container
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: memory_limit
+  ##     value: "256M"
+  ##
+  extraEnvVars: []
+  ## @param migrateJob.extraEnvVarsCM Name of existing ConfigMap containing extra env vars
+  ##
+  extraEnvVarsCM: ""
+  ## @param migrateJob.extraEnvVarsSecret Name of existing Secret containing extra env vars
+  ##
+  extraEnvVarsSecret: ""
+  ## @param migrateJob.extraVolumes Optionally specify extra list of additional volumes for the Nominatim migration pod
+  ##
+  extraVolumes: []
+  ## @param migrateJob.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Nominatim migration container
+  ##
+  extraVolumeMounts: []
+  ## @param migrateJob.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).
+  ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+  ##
+  resourcesPreset: "micro"
+  ## @param migrateJob.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ##
+  resources: {}
+
   ## K8s CronJob configuration
   ## ref: https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/
   ##


### PR DESCRIPTION
## What

- New `templates/migrateJob.yaml`: a Job annotated `helm.sh/hook: post-install,post-upgrade` running `nominatim admin --migrate`. `hook-delete-policy: before-hook-creation`, so the previous run's logs stay around until the next upgrade.
- Guarded so it never fails a release for the wrong reason: it waits for the database (`migrateJob.dbWaitTimeout`), exits 0 when no Nominatim database exists yet, and is skipped entirely while `initJob.enabled` is set. `nominatim admin --migrate` itself already exits 0 when the database is at the deployed version.
- New `migrateJob.*` values block, README parameter table, a "Database migration" section and an Upgrading note.
- Chart version 6.1.0 -> 6.2.0.

Two defaults worth a look:

- `migrateJob.enabled` defaults to `true`. Since Renovate bumps `appVersion` on its own, a user who never migrates ends up with a new Nominatim against an old schema, which is the situation the issue describes. Happy to flip it to opt-in if you'd rather not change behaviour for existing installs.
- `migrateJob.backoffLimit` is `1` rather than `initJob`'s `0`. A migration is idempotent, so a single transient database blip shouldn't fail the whole release.

## Why

Closes #194. With a GitOps flow there is no natural place to run the migration by hand, so an upgrade that changes the Nominatim version silently leaves the database behind. ArgoCD maps Helm's `post-upgrade` hook to `PostSync`, so the hook fits that flow without extra machinery.

Verified with `helm lint` plus `helm template` over the combinations that matter: defaults, `initJob.enabled=true`, `migrateJob.enabled=false`, `externalDatabase.existingSecretDsn`, `flatnode.enabled=true` and `diagnosticMode.enabled=true`. Not yet run against a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)