### PR TITLE
nominatim: allow init containers and sidecars on the migration job

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.2.2
+version: 6.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nominatim/README.md
+++ b/charts/nominatim/README.md
@@ -249,6 +249,8 @@ Note: The command above may differ a little depending the k8s cluster version yo
 | `migrateJob.extraEnvVars`                                     | Array with extra environment variables to add to the Nominatim container                                                                                                                                         | `[]`             |
 | `migrateJob.extraEnvVarsCM`                                   | Name of existing ConfigMap containing extra env vars                                                                                                                                                             | `""`             |
 | `migrateJob.extraEnvVarsSecret`                               | Name of existing Secret containing extra env vars                                                                                                                                                                | `""`             |
+| `migrateJob.initContainers`                                   | Add additional init containers to the Nominatim migration pod, including native sidecars (`restartPolicy: Always`) such as a database proxy                                                                       | `[]`             |
+| `migrateJob.sidecars`                                         | Add additional sidecar containers to the Nominatim migration pod. Only for containers that terminate on their own                                                                                                 | `[]`             |
 | `migrateJob.extraVolumes`                                     | Optionally specify extra list of additional volumes for the Nominatim migration pod                                                                                                                              | `[]`             |
 | `migrateJob.extraVolumeMounts`                                | Optionally specify extra list of additional volumeMounts for the Nominatim migration container                                                                                                                   | `[]`             |
 | `migrateJob.resourcesPreset`                                  | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `micro`          |
@@ -515,6 +517,12 @@ deployed release, and also when no Nominatim database exists yet. It is skipped 
 because during the initialisation phase the database is built from scratch anyway.
 
 Set `migrateJob.enabled: false` to opt out and migrate manually.
+
+When the database is reached through a proxy (Cloud SQL Auth Proxy, AlloyDB Auth Proxy, or similar), add it under
+`migrateJob.initContainers` with `restartPolicy: Always` so it becomes a
+[native sidecar](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/). A proxy placed in
+`migrateJob.sidecars` never exits, so the pod would keep running after the migration finishes and the Job would never
+complete.
 
 ### PVC For data
 

--- a/charts/nominatim/templates/migrateJob.yaml
+++ b/charts/nominatim/templates/migrateJob.yaml
@@ -47,6 +47,10 @@ spec:
       {{- if .Values.migrateJob.podSecurityContext.enabled }}
       securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.migrateJob.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.migrateJob.initContainers }}
+      initContainers:
+        {{- include "common.tplvalues.render" (dict "value" .Values.migrateJob.initContainers "context" $) | nindent 8 }}
+      {{- end }}
       containers:
         - name: nominatim-migrate
           image: {{ include "nominatim.image" . }}
@@ -140,6 +144,9 @@ spec:
           {{- else if ne .Values.migrateJob.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.migrateJob.resourcesPreset) | nindent 12 }}
           {{- end }}
+        {{- if .Values.migrateJob.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.migrateJob.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       volumes:
         {{- if .Values.flatnode.enabled }}
         - name: nominatim

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -784,6 +784,29 @@ migrateJob:
   ## @param migrateJob.extraEnvVarsSecret Name of existing Secret containing extra env vars
   ##
   extraEnvVarsSecret: ""
+  ## @param migrateJob.initContainers Add additional init containers to the Nominatim migration pod
+  ## Also the place for a native sidecar (an init container with `restartPolicy: Always`), which is
+  ## what a database proxy has to be here: a plain sidecar container never exits, so the Job would
+  ## never complete.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+  ## e.g:
+  ## initContainers:
+  ##  - name: cloud-sql-proxy
+  ##    image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:latest
+  ##    restartPolicy: Always
+  ##    args: ['--port=5432', 'project:region:instance']
+  ##
+  initContainers: []
+  ## @param migrateJob.sidecars Add additional sidecar containers to the Nominatim migration pod
+  ## Only for containers that terminate on their own; anything long-running belongs in
+  ## `migrateJob.initContainers` as a native sidecar, or the Job never completes.
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##
+  sidecars: []
   ## @param migrateJob.extraVolumes Optionally specify extra list of additional volumes for the Nominatim migration pod
   ##
   extraVolumes: []


### PR DESCRIPTION
## What

- Adds `migrateJob.initContainers` and `migrateJob.sidecars`, both defaulting to `[]`.
- Documents in the README that a database proxy belongs in `migrateJob.initContainers` as a native sidecar.
- Chart 6.2.2 -> 6.3.0.

## Why

- `migrateJob` is the only pod spec in the chart that cannot take extra containers. The Deployment has both `sidecars` and `initContainers`; the init and updates Jobs have `initContainers`; `migrateJob` has only `extraEnvVars` and `extraVolumes`. So there is no way to reach a database behind a proxy (Cloud SQL Auth Proxy and friends), and a wrapper chart cannot inject a container into a subchart template either.
- `initContainers` is the half that matters: a proxy has to be a [native sidecar](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/) (`restartPolicy: Always`) or it never exits, the pod keeps running after the migration finishes, and the Job never completes. `sidecars` is for parity with the Deployment, documented for containers that terminate on their own.
- Rendered output is unchanged when both are empty — the `initContainers` key is omitted entirely.