### PR TITLE
nominatim: allow extra init containers and sidecars on the init job

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.3.0
+version: 6.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nominatim/README.md
+++ b/charts/nominatim/README.md
@@ -220,6 +220,8 @@ Note: The command above may differ a little depending the k8s cluster version yo
 | `initJob.resourcesPreset`           | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `micro`                                             |
 | `initJob.resources`                 | Set container requests and limits for different resources like CPU or memory (essential for production workloads)                                                                                                 | `{}`                                                |
 | `initJob.continue`                  | Select init step to continue from                                                                                                                                                                                 | `nil` `[ load-data \| indexing \| db-postprocess ]` |
+| `initJob.extraInitContainers`       | Add additional init containers to the Nominatim init pod, rendered before `wait-for-db`                                                                                                                           | `[]`                                                |
+| `initJob.sidecars`                  | Add additional sidecar containers to the Nominatim init pod, for containers that terminate on their own                                                                                                           | `[]`                                                |
 | `initJob.extraEnvVars`              | Array with extra environment variables to add to the Nominatim container                                                                                                                                          | `[]`                                                |
 | `initJob.extraEnvVarsCM`            | Name of existing ConfigMap containing extra env vars                                                                                                                                                              | `""`                                                |
 | `initJob.extraEnvVarsSecret`        | Name of existing Secret containing extra env vars                                                                                                                                                                 | `""`                                                |
@@ -523,6 +525,9 @@ When the database is reached through a proxy (Cloud SQL Auth Proxy, AlloyDB Auth
 [native sidecar](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/). A proxy placed in
 `migrateJob.sidecars` never exits, so the pod would keep running after the migration finishes and the Job would never
 complete.
+
+The same applies to the init Job, via `initJob.extraInitContainers` — rendered ahead of the built-in `wait-for-db`, so
+the proxy is already up when the database is first probed.
 
 ### PVC For data
 

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -26,6 +26,9 @@ spec:
       securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.initJob.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
+        {{- if .Values.initJob.extraInitContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initJob.extraInitContainers "context" $) | nindent 8 }}
+        {{- end }}
         - name: wait-for-db
           image: {{ .Values.initJob.initContainers.waitForDB.image }}
           env:
@@ -271,6 +274,9 @@ spec:
           resources:
             {{- toYaml .Values.initJob.resources | nindent 12 }}
           {{- end }}
+        {{- if .Values.initJob.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initJob.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -676,6 +676,25 @@ initJob:
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
+  ## @param initJob.extraInitContainers Add additional init containers to the Nominatim init pod, rendered before `wait-for-db`
+  ## A database proxy belongs here as a native sidecar (`restartPolicy: Always`): it is rendered first, so it is
+  ## already running by the time `wait-for-db` tries to connect. A plain sidecar container never exits and the Job
+  ## would never complete. This is a separate key because `initJob.initContainers` is a map configuring the images
+  ## of the built-in init containers, not a list.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+  ## e.g:
+  ## extraInitContainers:
+  ##  - name: cloud-sql-proxy
+  ##    image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:latest
+  ##    restartPolicy: Always
+  ##    args: ['--port=5432', 'project:region:instance']
+  ##
+  extraInitContainers: []
+  ## @param initJob.sidecars Add additional sidecar containers to the Nominatim init pod
+  ## Only for containers that terminate on their own; anything long-running belongs in
+  ## `initJob.extraInitContainers` as a native sidecar, or the Job never completes.
+  ##
+  sidecars: []
   ## @param initJob.extraEnvVars Array with extra environment variables to add to the Nominatim container
   ## e.g:
   ## extraEnvVars:


### PR DESCRIPTION
Apologies for the run of nominatim PRs one after the other — and specifically for not catching this one in #212. I checked `migrateJob` and `updates` and concluded the init Job was already covered, which was wrong: `initJob.initContainers` is a map of built-in images, not a list. Nothing here is urgent or blocking on my end, so merge it whenever suits you.

## What

- Adds `initJob.extraInitContainers` and `initJob.sidecars`, both defaulting to `[]`.
- `extraInitContainers` renders *before* the built-in `wait-for-db`.
- Chart 6.3.0 -> 6.4.0.

## Why

- After #212 the init Job is the only pod spec in the chart that cannot take extra containers, and it is the one that most needs them: it builds the database from scratch and its first init container is `wait-for-db` connecting to Postgres. Behind a proxy there is no way to make that reachable.
- New key rather than widening `initJob.initContainers`, because that one is a map configuring the images of the built-in init containers — turning it into a list would break every chart setting those.
- The ordering is load-bearing, not cosmetic: a native sidecar (`restartPolicy: Always`) is only useful to a later init container if it starts first, so appending would be too late for `wait-for-db`.
- Rendered output is unchanged when both are empty.